### PR TITLE
Clone googletest into the $HOME folder instead.

### DIFF
--- a/c_cpp/Dockerfile
+++ b/c_cpp/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Coursemology <coursemology@googlegroups.com>
 
 RUN apt-get update && apt-get install -y --force-yes \
 	build-essential git \
-  && git clone https://github.com/google/googletest.git /lib/googletest \
+  && git clone https://github.com/google/googletest.git $HOME/googletest \
   && apt-get remove -y git \
 	&& rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This allows the same Makefile to be used for local testing as the
GTEST_DIR path can be kept the same for both local testing and the
evaluator container.