### PR TITLE
Precompile GoogleTest libraries.

### DIFF
--- a/c_cpp/Dockerfile
+++ b/c_cpp/Dockerfile
@@ -12,5 +12,14 @@ RUN apt-get update && apt-get install -y --force-yes \
   && apt-get autoremove -y \
 	&& rm -rf /var/lib/apt/lists/*
 
+# Compile GTest libraries so they do not need to be compiled on each evaluation
+# After compilation, copy to GTEST_DIR
+ENV GTEST_DIR $HOME/googletest/googletest
+
+RUN cd $GTEST_DIR/make \
+  && make gtest_main.a \
+  && make gtest.a \
+  && cp gtest_main.a gtest.a $GTEST_DIR
+
 # Set env var for GoogleTest to output an xml report file
 ENV GTEST_OUTPUT xml:./report.xml


### PR DESCRIPTION
Allows evaluator packages to just copy them instead of recompiling on
each evaluation.

Set `GTEST_DIR` environment variable.