### PR TITLE
Build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,8 +3,9 @@
 BASE_FOLDER=base
 CURRENT_PATH=$(pwd)
 
-# Function to build images for folders where the Dockerfile is at the top level.
+# Function to build images (without version tags) for folders where the Dockerfile is at the top level.
 # This is the case for the base and languages for which only a single version is supported.
+# Any image that differs from it should have its on build script.
 build_generic() {
   FOLDER=$1
   cd $FOLDER
@@ -20,8 +21,21 @@ build_generic() {
   cd $CURRENT_PATH
 }
 
+build() {
+  # Look for build.sh in the folder, if it doesn't exist use the generic build method.
+  FOLDER=$1
+  NEXT_PATH=$CURRENT_PATH/$FOLDER
+  if [ -f $NEXT_PATH/build.sh ]; then
+    cd $NEXT_PATH
+    bash build.sh
+    cd $CURRENT_PATH
+  else
+    build_generic $FOLDER
+  fi
+}
+
 # Build the base docker image first.
-build_generic $BASE_FOLDER
+build $BASE_FOLDER
 
 for f in $(pwd)/*;
   do
@@ -36,11 +50,5 @@ for f in $(pwd)/*;
       continue
     fi
 
-    # Look for build.sh in the folder, if it doesn't exist use the generic build method.
-    if [ -f $f/build.sh ]; then
-      cd $f
-      bash $f/build.sh
-    else
-      build_generic $FOLDER_NAME
-    fi
+    build $FOLDER_NAME
   done;

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+BASE_FOLDER=base
+CURRENT_PATH=$(pwd)
+
+# Function to build images for folders where the Dockerfile is at the top level.
+# This is the case for the base and languages for which only a single version is supported.
+build_generic() {
+  FOLDER=$1
+  cd $FOLDER
+
+  REGISTRY=coursemology
+  IMAGE_NAME=$REGISTRY/evaluator-image-$FOLDER
+
+  echo "IN $(pwd)"
+  echo "Building $IMAGE_NAME"
+
+  docker build -t $IMAGE_NAME .
+
+  cd $CURRENT_PATH
+}
+
+# Build the base docker image first.
+build_generic $BASE_FOLDER
+
+for f in $(pwd)/*;
+  do
+    if [ ! -d $f ]; then
+      continue
+    fi
+
+    FOLDER_NAME=`basename $f`
+
+    # This is the folder with the Dockerfile for the base image. Skip it since it has already been built
+    if [ $FOLDER_NAME == $BASE_FOLDER ]; then
+      continue
+    fi
+
+    # Look for build.sh in the folder, if it doesn't exist use the generic build method.
+    if [ -f $f/build.sh ]; then
+      cd $f
+      bash $f/build.sh
+    else
+      build_generic $FOLDER_NAME
+    fi
+  done;

--- a/python/build.sh
+++ b/python/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+REGISTRY=coursemology
+NAME_SUFFIX=`basename $(pwd)`
+NAME=evaluator-image-$NAME_SUFFIX
+IMAGE_NAME=$REGISTRY/$NAME
+
+build() {
+  TAG=$1
+  IMAGE_NAME=$REGISTRY/$NAME:$TAG
+
+  echo "IN $(pwd)"
+  echo "Building $IMAGE_NAME"
+
+  docker build -t $IMAGE_NAME .
+}
+
+# Iterate over all pythonX folders and build with tag X
+for f in $(pwd)/*;
+  do
+    if [ -d $f ]; then
+      cd "$f"
+      FOLDER_NAME=`basename $f`
+      build ${FOLDER_NAME:6}
+    fi
+  done;


### PR DESCRIPTION
Script to build the image for each supported language.

The default method `build_generic`, assumes that the `Dockerfile` is defined in `folder/` and the desired image name is `coursemology/evaluator-image-folder`. If deviations are required, a script to build the image should be defined in `folder/build.sh`.

Result:
<img width="802" alt="screen shot 2017-10-13 at 7 17 37 am" src="https://user-images.githubusercontent.com/2408722/31523605-14eea9be-afe7-11e7-9cf6-5aaf34a98cba.png">
