### PR TITLE
Fix invalid jessie-backports repository.

### DIFF
--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -4,8 +4,8 @@ MAINTAINER Coursemology <coursemology@googlegroups.com>
 # Set HOME variable to a location accessible by the coursemology user
 ENV HOME /home/coursemology
 
-RUN echo 'deb http://http.debian.net/debian jessie-backports main' >> /etc/apt/sources.list \
-	&& apt-get update \
+RUN echo 'deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main' >> /etc/apt/sources.list \
+	&& apt-get -o Acquire::Check-Valid-Until=false update \
 	&& apt-get install -y wget \
 	&& cd $HOME \
 	&& mkdir lib \


### PR DESCRIPTION
Needed for building Java image on Debian 8.

References:

https://unix.stackexchange.com/questions/508724/failed-to-fetch-jessie-backports-repository
https://unix.stackexchange.com/questions/2544/how-to-work-around-release-file-expired-problem-on-a-local-mirror 