### PR TITLE
Compile GTest with C++11

### DIFF
--- a/c_cpp/Dockerfile
+++ b/c_cpp/Dockerfile
@@ -35,6 +35,7 @@ ENV GTEST_DIR $HOME/googletest/googletest
 RUN cd $GTEST_DIR/ \
   && g++ -isystem ${GTEST_DIR}/include -I${GTEST_DIR} \
      -pthread -c ${GTEST_DIR}/src/gtest-all.cc \
+     -std=c++11 \
   && ar -rv libgtest.a gtest-all.o
 
 # Set env var for GoogleTest to output an xml report file


### PR DESCRIPTION
To address the following error in recent failed builds of `coursemology/evaluator-image-c_cpp`:

```
Step 7/8 : RUN cd $GTEST_DIR/ && g++ -isystem ${GTEST_DIR}/include -I${GTEST_DIR} -pthread -c ${GTEST_DIR}/src/gtest-all.cc && ar -rv libgtest.a gtest-all.o
---> Running in 08eed6ade609
In file included from /usr/include/c++/4.9/type_traits:35:0,
from /home/coursemology/googletest/googletest/include/gtest/gtest.h:59,
from /home/coursemology/googletest/googletest/src/gtest-all.cc:38:
/usr/include/c++/4.9/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard.
This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
```

See https://cloud.docker.com/u/coursemology/repository/docker/coursemology/evaluator-image-c_cpp