### PR TITLE
Reduce Python 3.7 Docker image size by using CPU only version of pytorch

### DIFF
--- a/python/python3.7/Dockerfile
+++ b/python/python3.7/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update && apt-get install --force-yes -y wget \
   && pip3 install scipy \
   && pip3 install matplotlib \
   && pip3 install pandas \
-  && pip3 install torch torchvision \
+  && pip3 install sklearn \
+  && pip3 install torch==1.2.0+cpu torchvision==0.4.0+cpu -f https://download.pytorch.org/whl/torch_stable.html \
   && cd /root \
   && rm -r /root/Python-3.7.2 \
   && rm -r /root/Python-3.7.2.tgz \

--- a/python/python3.7/Dockerfile
+++ b/python/python3.7/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install --force-yes -y wget \
   && ./configure \
   && make \
   && make install \
+  && pip3 install --upgrade pip \
   && pip3 install git+https://github.com/Coursemology/unittest-xml-reporting.git@extra-attributes \
   && pip3 install timeout-decorator \
   && pip3 install Pillow \


### PR DESCRIPTION
As suggested by @MartinStrobel in #34.

Also upgrade `pip` to resolve warning messages when building.

