### PR TITLE
feat(evaluator-images): upload evaluator image archives to s3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,115 @@
+version: 2.1
+
+orbs:
+  aws-cli: circleci/aws-cli@4.0
+
+commands:
+  aws_login:
+    parameters:
+      AWS_ROLE_ARN:
+        type: string
+    steps:
+      - aws-cli/setup:
+          role_arn: << parameters.AWS_ROLE_ARN >>
+
+  list_existing_archives:
+    parameters:
+      S3_EVALUATOR_IMAGE_BUCKET:
+        type: string
+    steps:
+      - run:
+          name: Get list of existing archives
+          command: |
+            aws s3 ls s3://<< parameters.S3_EVALUATOR_IMAGE_BUCKET >> > existing_evaluator_images.list
+
+  docker_login:
+    parameters:
+      DOCKER_USERNAME:
+        type: string
+      DOCKER_PASSWORD:
+        type: string
+    steps:
+      - run:
+          name: docker login
+          command: docker login -u << parameters.DOCKER_USERNAME >> -p << parameters.DOCKER_PASSWORD >>
+
+  save_docker_archive:
+    steps:
+      - run:
+          name: Pull evaluator images and save to local archives
+          command: |
+            while read image; do
+              ARCHIVE_NAME=$(echo "$image" | sed -E 's|coursemology/||; s|:|_|; s|\.|_|').tar.gz
+             
+              if grep -q "$ARCHIVE_NAME" existing_evaluator_images.list; then
+                echo "Archive $ARCHIVE_NAME already exists"
+                continue
+              fi
+
+              echo "Creating archive $ARCHIVE_NAME"
+              docker pull "$image"
+              docker save "$image" | pigz --fast > "$ARCHIVE_NAME"
+            done < evaluator-images.list
+
+  upload_archive_to_aws:
+    parameters:
+      S3_EVALUATOR_IMAGE_BUCKET:
+        type: string
+    steps:
+      - run:
+          name: Upload image archives to S3
+          command: |
+            for archive in ./*.tar.gz; do
+              [ -e "$archive" ] || continue
+              aws s3 cp $archive s3://<< parameters.S3_EVALUATOR_IMAGE_BUCKET >> --copy-props none
+            done
+
+jobs:
+  save-and-upload-to-staging:
+    machine:
+      image: ubuntu-2204:2024.01.1
+    resource_class: large
+    steps:
+      - checkout
+      - aws_login:
+          AWS_ROLE_ARN: ${AWS_STAGING_ROLE_ARN}
+      - list_existing_archives:
+          S3_EVALUATOR_IMAGE_BUCKET: ${AWS_STAGING_S3_EVALUATOR_IMAGE_BUCKET}
+      - docker_login:
+          DOCKER_USERNAME: ${DOCKER_USERNAME}
+          DOCKER_PASSWORD: ${DOCKER_PASSWORD}
+      - save_docker_archive
+      - upload_archive_to_aws:
+          S3_EVALUATOR_IMAGE_BUCKET: ${AWS_STAGING_S3_EVALUATOR_IMAGE_BUCKET}
+
+  save-and-upload-to-production:
+    machine:
+      image: ubuntu-2204:2024.01.1
+    resource_class: large
+    steps:
+      - checkout
+      - aws_login:
+          AWS_ROLE_ARN: ${AWS_PRODUCTION_ROLE_ARN}
+      - list_existing_archives:
+          S3_EVALUATOR_IMAGE_BUCKET: ${AWS_PRODUCTION_S3_EVALUATOR_IMAGE_BUCKET}
+      - docker_login:
+          DOCKER_USERNAME: ${DOCKER_USERNAME}
+          DOCKER_PASSWORD: ${DOCKER_PASSWORD}
+      - save_docker_archive
+      - upload_archive_to_aws:
+          S3_EVALUATOR_IMAGE_BUCKET: ${AWS_PRODUCTION_S3_EVALUATOR_IMAGE_BUCKET}
+
+workflows:
+  version: 2
+  save-and-upload:
+    jobs:
+      - save-and-upload-to-staging:
+          filters:
+            branches:
+              ignore:
+                - master
+      - save-and-upload-to-production:
+          filters:
+            branches:
+              only:
+                - master

--- a/README.md
+++ b/README.md
@@ -123,3 +123,17 @@ Cleaning up if the prepared file has been messed up:
 ```
 make clean
 ```
+
+## Deployment of Evaluator Images
+
+Each programming language supported by Coursemology's default evaluator requires its corresponding Docker image to be preloaded on worker instances. If the image is absent, it will be loaded as part of the autograding job, which will adversely effect its runtime.
+
+The [evaluator-images.list](./evaluator-images.list) file contains the list of all evaluator images currently in use. Whenever a new evaluator image is created, add it to this file as a new entry.
+
+
+Whenever a pull request is created, a CircleCI orb will sync the images listed in the file with a storage bucket in our AWS S3 staging environment. If an image archive doesn't exist in the bucket yet, it will pulls the image, run `docker save` to create a .tar.gz archive for it, then upload it to the bucket. During deployment of our worker instances, our evaluator images are loaded from the bucket instead of calling `docker pull`.
+
+When the pull request is merged, the same process happens in our production environment. 
+
+
+In exceptional circumstances where we need to patch an existing evaluator image and update its archive, the old archive must be manually deleted.

--- a/evaluator-images.list
+++ b/evaluator-images.list
@@ -1,0 +1,14 @@
+coursemology/evaluator-image-c_cpp:17
+coursemology/evaluator-image-c_cpp:11
+coursemology/evaluator-image-java:21
+coursemology/evaluator-image-java:17
+coursemology/evaluator-image-java:11
+coursemology/evaluator-image-java:8
+coursemology/evaluator-image-python:3.12
+coursemology/evaluator-image-python:3.10
+coursemology/evaluator-image-python:3.9
+coursemology/evaluator-image-python:3.7
+coursemology/evaluator-image-python:3.6
+coursemology/evaluator-image-python:3.5
+coursemology/evaluator-image-python:3.4
+coursemology/evaluator-image-python:2.7


### PR DESCRIPTION
- use [docker authenticated pulls](https://circleci.com/docs/private-images/)
- skip docker pull/save when archive already exists